### PR TITLE
fix: Danger should not throw an error for an empty PR (#15)

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -159,8 +159,10 @@ function hasOnlyPixelChanges(gitChanges) {
 
 async function run() {
   if (danger.github.thisPR) {
-    if (!hasOnlyPixelChanges(danger.git)) {
-      await handleMultipleFileChanges();
+    if ((await danger.git.linesOfCode()) === 0) {
+      fail('This PR is empty and needs a manual review');
+    } else if (!hasOnlyPixelChanges(danger.git)) {
+      await handleMultipleFileChanges(danger.git);
     } else {
       const jsonPatch = await danger.git.JSONPatchForFile('_data/pixels.json');
       const passed = await evaluatePixelChanges(jsonPatch);


### PR DESCRIPTION
## Checklist

- [x] I ran `npm test` locally and it passed without errors.
- [ ] I only edited the `_data/pixels.json` file.
- [ ] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
- [x] I acknowledge that all my contributions will be made under the project's [license](../../LICENSE.md).

## Description

This fixes #15. Danger now checks the number of lines actually modified by a PR (via the `linesOfCode()` function of the [GitDSL](https://danger.systems/js/reference.html#GitDSL) and fails with the message indicated in the issue if no lines were actually modified.

Output of `npx danger pr https://github.com/twilio-labs/open-pixel-art/pull/14`:

```
Starting Danger PR on twilio-labs/open-pixel-art#14

Danger: ⅹ Failing the build, there is 1 fail.
## Failures
This PR is empty and needs a manual review
```