### PR TITLE
fix: improve danger diff checking

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -59,9 +59,13 @@ async function evaluatePixelChanges(jsonPatch) {
       );
     }
   } else {
-    if (!allPatchesAreForTheSamePixel(jsonPatch.diff)) {
+    if (!allPatchesAreForTheSamePixel(jsonPatch)) {
       return false;
     } else {
+      if (jsonPatch.diff.length === 0) {
+        fail('This PR appears to be empty and needs a manual review');
+        return false;
+      }
       return isValidPixelUpdate(jsonPatch, jsonPatch.diff[0], gitHubUsername);
     }
   }
@@ -72,7 +76,38 @@ function getIndexFromPath(diffPath) {
   return parseInt(diffPath.replace('/data/', '').match(/^\d*/)[0], 10);
 }
 
-function allPatchesAreForTheSamePixel(diffs) {
+function hasOperation(diffs, operation) {
+  for (const diff of diffs) {
+    if (diff.op === operation) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function allPatchesAreForTheSamePixel(jsonPatch) {
+  const diffs = jsonPatch.diff;
+
+  if (hasOperation(diffs, 'remove')) {
+    const removePatches = diffs
+      .filter(x => x.op === 'remove')
+      .map(x => getIndexFromPath(x.path))
+      .map(idx => jsonPatch.before.data[idx])
+      .map(pixel => pixel.username)
+      .filter(username => username !== '<UNCLAIMED>');
+
+    fail(
+      'It seems like you are accidentally deleting some contributions of others. Please make sure you have pulled the latest changes from the master branch and resolved any merge conflicts. https://help.github.com/en/articles/syncing-a-fork'
+    );
+    fail(
+      `Make sure that the following usernames are indeed included: ${removePatches.join(
+        ','
+      )}`
+    );
+    return false;
+  }
+
   let currentPixelIndex = undefined;
   for (let diff of diffs) {
     const idx = getIndexFromPath(diff.path);

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -97,15 +97,17 @@ function allPatchesAreForTheSamePixel(jsonPatch) {
       .map(pixel => pixel.username)
       .filter(username => username !== '<UNCLAIMED>');
 
-    fail(
-      'It seems like you are accidentally deleting some contributions of others. Please make sure you have pulled the latest changes from the master branch and resolved any merge conflicts. https://help.github.com/en/articles/syncing-a-fork'
-    );
-    fail(
-      `Make sure that the following usernames are indeed included: ${removePatches.join(
-        ','
-      )}`
-    );
-    return false;
+    if (removePatches.length > 0) {
+      fail(
+        'It seems like you are accidentally deleting some contributions of others. Please make sure you have pulled the latest changes from the master branch and resolved any merge conflicts. https://help.github.com/en/articles/syncing-a-fork'
+      );
+      fail(
+        `Make sure that the following usernames are indeed included: ${removePatches.join(
+          ','
+        )}`
+      );
+      return false;
+    }
   }
 
   let currentPixelIndex = undefined;


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [] I only edited the `_data/pixels.json` file.
- [] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
- [x] I acknowledge that all my contributions will be made under the project's [license](../../LICENSE.md).

<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description

Some PRs were causing oddities with Danger because the changes were out of sync with master. This PR will improve error messages by letting people know that they should pull from upstream.

## Related issues

fixes #37 