### PR TITLE
feat: add Screen Reader Accessibility improvements

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -32,6 +32,9 @@
       </hgroup>
       <nav>
         <ul class="nav-list">
+          <li class="screenreader-only">
+            <a href="#canvas">Go to the Pixel Art Canvas</a>
+          </li>
           <li class="nav-item">
             <a class="nes-btn" href="#about">About the Project</a>
           </li>
@@ -42,14 +45,15 @@
             <a class="nes-btn" href="#contributors">See All Contributors</a>
           </li>
           <li class="nav-item">
-            <a class="nes-btn external-link" href="https://github.com/twilio-labs/open-pixel-art" target="_blank" rel="noreferrer" >View on GitHub</a>
+            <a class="nes-btn external-link" href="https://github.com/twilio-labs/open-pixel-art" target="_blank" rel="noreferrer" aria-label="Check on Github">View on GitHub</a>
           </li>
         </ul>
       </nav>
     </header>
 
     <main role="main">
-      <section id="canvas" class="nes-container with-title">
+      <section  id="canvas" class="nes-container with-title" aria-label="You are in the Pixel Art Canvas. Hover over a pixel to hear the github username who contributed it.">
+        <div role="heading" aria-level="2" class="screenreader-only">Pixel Art Canvas</div>
         <svg viewbox="0 0 {{defaults.image.width * defaults.image.scale}} {{defaults.image.height * defaults.image.scale}}">
           <rect x="0" y="0" width="100%" height="100%" style="fill: {{defaults.image.background}}"/>
           {% for pixel in pixels.data %}
@@ -74,8 +78,8 @@
       </section>
       <section class="nes-container with-title">
         <h2 class="title" id="contributor">Contributor</h2>
-        <p>Hover over any pixel to see the username of the person who contributed it.</p>
-        <p>That pixel was contributed by: <span id="contributor-name">no pixel hovered</span></p>
+        <p aria-label="Hover over any pixel to hear the github username who contributed it.">Hover over any pixel to see the username of the person who contributed it.</p>
+        <p>That pixel was contributed by: <span id="contributor-name" aria-live="polite">no pixel hovered</span></p>
       </section>
       <section class="nes-container with-title">
         <h2 class="title" id="about">About the Project</h2>
@@ -144,11 +148,10 @@
     </main>
     <footer class="text-center">
       <p class="footer-icons">
-        <a class="external-link" href="https://github.com/twilio-labs/open-pixel-art" target="_blank" rel="noreferrer" >
+        <a class="external-link" href="https://github.com/twilio-labs/open-pixel-art" target="_blank" rel="noreferrer" aria-label="Check Project on Github">
           <i class="nes-icon github" aria-hidden="true"></i>
-          <span class="screenreader-only">View on GitHub</span>
         </a>
-        <a class="external-link" href="https://www.twilio.com/labs?utm_source=hacktoberfest19&utm_campaign=hacktoberfest19" target="_blank" rel="noreferrer" >
+        <a class="external-link" href="https://www.twilio.com/labs?utm_source=hacktoberfest19&utm_campaign=hacktoberfest19" target="_blank" rel="noreferrer" aria-label="Check Twilio's Featured Projects for Contribution">
           <img src="/assets/twilioBug.svg" alt="pixelated Twilio logo" class="twilio-pixel"/>
         </a>
       </p>

--- a/styles/main.css
+++ b/styles/main.css
@@ -105,7 +105,13 @@ p code {
 }
 
 .screenreader-only {
-  display: none;
+  opacity: 0.01;
+  width: 1px;
+  height: 1px;
+}
+
+.screenreader-only:hover, .screenreader-only:link, .screenreader-only:visited {
+  cursor: arrow;
 }
 
 .twilio-pixel {


### PR DESCRIPTION
## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [ ] I only edited the `_data/pixels.json` file.
- [ ] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
- [x] I acknowledge that all my contributions will be made under the project's [license](../../LICENSE.md).

## Description
- Added screen reader only nav link to canvas (Hidden for vident users)
- Added canvas section description so non-vident users know where they are and with what purpose
- Added aria-live="polite" so SR can listen/detect & read DOM changes in span#contributor-name

![canvas](https://user-images.githubusercontent.com/36349751/66239253-c2a93a80-e6cf-11e9-9c91-712a876a8b3f.png)

_===================================_

- Added aria-labels for footer links

![Screenshot from 2019-10-04 17-17-27](https://user-images.githubusercontent.com/36349751/66239269-d18fed00-e6cf-11e9-8e22-db65b8dd9158.png)

_===================================_

- Modified .screenreader-only class because display:none DOES NOT WORK in modern SRs

Sources:
https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#CSS
![Screenshot from 2019-10-04 17-55-44](https://user-images.githubusercontent.com/36349751/66239433-3ba89200-e6d0-11e9-910c-5c798a380711.png)

https://a11yproject.com/posts/how-to-hide-content/
![Screenshot from 2019-10-04 17-57-35](https://user-images.githubusercontent.com/36349751/66239529-7ad6e300-e6d0-11e9-9592-79a4e20b0a50.png)


