### PR TITLE
fix: change `.screenreader-only` index #374

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -108,6 +108,7 @@ p code {
   opacity: 0.01;
   width: 1px;
   height: 1px;
+  z-index: -1;
 }
 
 .screenreader-only:hover,


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

<!-- Delete this if the PR is for something other than a pixel -->
- [ ] I ran `npm test` locally and it passed without errors.
- [ ] I only edited the `_data/pixels.json` file.
<!-- Delete this if the PR is for something other than a pixel -->
- [ ] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
- [x] I acknowledge that all my contributions will be made under the project's [license](../../LICENSE.md).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->

<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description
This should fix sreenreader element from cover up the canvas element.

## Related issues
#374 

<!-- OTHER CONTRIBUTIONS // END -->
