### PR TITLE
[FIX] License File points to 404

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 - [ ] I only edited the `_data/pixels.json` file.
 <!-- Delete this if the PR is for something other than a pixel -->
 - [ ] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
-- [ ] I acknowledge that all my contributions will be made under the project's [license](../../LICENSE.md).
+- [ ] I acknowledge that all my contributions will be made under the project's [license](LICENSE).
 
 <!-- To check a task, put a "x" between the brackets, similar to [x] -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 - [ ] I only edited the `_data/pixels.json` file.
 <!-- Delete this if the PR is for something other than a pixel -->
 - [ ] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
-- [ ] I acknowledge that all my contributions will be made under the project's [license](LICENSE).
+- [ ] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).
 
 <!-- To check a task, put a "x" between the brackets, similar to [x] -->
 


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [X] I ran `npm test` locally and it passed without errors.
- [X] I acknowledge that all my contributions will be made under the project's [license](../../LICENSE.md).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

<!--

## Description

Every time a Pull request was to this repository the License file redirected to a 404 page. This Pull request aims to fix that 

## Related issues

N/A


-->

<!-- OTHER CONTRIBUTIONS // END -->
