### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/br/CODE_OF_CONDUCT.md
+++ b/docs/br/CODE_OF_CONDUCT.md
@@ -1,10 +1,10 @@
 # Código de Conduta do Colaborador
 
-¿Español? Puedes encontrar nuestro Código de Conducta traducido en [este enlace](/docs/es/CODE_OF_CONDUCT.md).
+¿Español? Puedes encontrar nuestro Código de Conducta traducido en [este enlace](../../docs/es/CODE_OF_CONDUCT.md).
 
-Deutsch? Du kannst unsere Verhaltensregeln [hier finden](/docs/de/CODE_OF_CONDUCT.md).
+Deutsch? Du kannst unsere Verhaltensregeln [hier finden](../../docs/de/CODE_OF_CONDUCT.md).
 
-Português do Brasil? Pode encontrar o nosso Codigo de Conduta traduzido em [neste link](/docs/br/CODE_OF_CONDUCT.md)
+Português do Brasil? Pode encontrar o nosso Codigo de Conduta traduzido em [neste link](../../docs/br/CODE_OF_CONDUCT.md)
 
 ## Nosso compromisso
 

--- a/docs/br/CODE_OF_CONDUCT.md
+++ b/docs/br/CODE_OF_CONDUCT.md
@@ -1,10 +1,10 @@
 # Código de Conduta do Colaborador
 
-¿Español? Puedes encontrar nuestro Código de Conducta traducido en [este enlace](docs/es/CODE_OF_CONDUCT.md).
+¿Español? Puedes encontrar nuestro Código de Conducta traducido en [este enlace](/docs/es/CODE_OF_CONDUCT.md).
 
-Deutsch? Du kannst unsere Verhaltensregeln [hier finden](docs/de/CODE_OF_CONDUCT.md).
+Deutsch? Du kannst unsere Verhaltensregeln [hier finden](/docs/de/CODE_OF_CONDUCT.md).
 
-Português do Brasil? Pode encontrar o nosso Codigo de Conduta traduzido em [neste link](docs/br/CODE_OF_CONDUCT.md)
+Português do Brasil? Pode encontrar o nosso Codigo de Conduta traduzido em [neste link](/docs/br/CODE_OF_CONDUCT.md)
 
 ## Nosso compromisso
 


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->


## Description

The links in the code of conduct file in Portuguese were broken because the relative path was wrong. So I fixed it.

<!-- OTHER CONTRIBUTIONS // END -->
