### PR TITLE
docs: update CONTRIBUTING.md to remove info about unclaimed pixels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,15 +77,10 @@ c861ba4389fe        open-pixel-art      "docker-entrypoint.s…"   7 minutes ago
 
 If you want to contribute a pixel, you have to open the [`_data/pixels.json`](_data/pixels.json) file. It contains every pixel placed on the canvas.
 
-There's two ways you can contribute a pixel.
+### Create a new pixel
 
-### Option 1: "Claim" a pixel
-
-Some entries in the `pixels.json` file exist but have a `username` property of `<UNCLAIMED>`. This means that you can change them to be your pixel. You can change the color to whatever you want. Afterwards change the `username` property to your GitHub username that you'll use to open the pull request with.
-
-### Option 2: Create a new pixel
-
-To create a new pixel, add a new row to the `data` array inside the `pixels.json`.
+To create a new pixel, search for a gap between the numbers for either the `x` or `y` coordinates in the `data` array inside the `pixels.json`.
+Once you have found an open position, ag ahead and add a new pixel row.
 A new pixel has to be an object with the following four properties:
 
 - `x`: The x-coordinate of your pixel. `0` is the left-most column of pixels

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ If you want to contribute a pixel, you have to open the [`_data/pixels.json`](_d
 ### Create a new pixel
 
 To create a new pixel, search for a gap between the numbers for either the `x` or `y` coordinates in the `data` array inside the `pixels.json`.
-Once you have found an open position, ag ahead and add a new pixel row.
+Once you have found an open position, go ahead and add a new pixel row.
 A new pixel has to be an object with the following four properties:
 
 - `x`: The x-coordinate of your pixel. `0` is the left-most column of pixels


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description
The contributing documentation states that there will be pixels marked with `<UNCLAIMED>` as the username, but that is not the case. There are no `<UNCLAIMED>` pixels, just simply holes in the numbers. That makes it very confusing for newcomers wanting to contribute for their first time. 

To help settle the confusion, I removed the part about the `<UNCLAIMED>` pixels and added a small sentence about looking for the gaps between the numbers.

## Related issues

This PR is referencing Issue #1317. 



<!-- OTHER CONTRIBUTIONS // END -->
