### PR TITLE
chore: add stale probot to auto-close issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,65 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+# onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+  - '[Status] Maybe Later'
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. 
+  Please re-open the issue if this issue is still relevant. 
+  Thank you for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  daysUntilStale: 10
+  daysUntilClose: 4
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. 
+    Feel free to open a new pull request to resubmit your contribution. Please make 
+    sure your [fork is synced](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork) before opening the pull request. 
+    Thank you for your contributions.
+
+issues:
+  exemptLabels:
+    - confirmed


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
<!-- Delete this if the PR is for something other than a pixel -->
- [ ] I only edited the `_data/pixels.json` file.
<!-- Delete this if the PR is for something other than a pixel -->
- [ ] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description

We have a lot of stale issues and PRs that could be closed because of a lack of activity. This adds a GitHub bot to take care of this.

## Related issues

N/A

<!-- OTHER CONTRIBUTIONS // END -->
