### PR TITLE
fix(pkg): upgrade https-proxy-agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4460,9 +4460,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
+      "integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
       "dev": true,
       "requires": {
         "agent-base": "^4.3.0",


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->


## Description

Hi and thank you for this nice initiative!

This PR upgrades package [`https-proxy-agent`](https://www.npmjs.com/package/https-proxy-agent) (from version 2.2.2 to 2.2.3) to avoid high vulnerability https://www.npmjs.com/advisories/1184 as reported by `npm audit` and when potential contributors simply run `npm install`.

This package is a transitive dependency of [`danger`](https://www.npmjs.com/package/danger) devDependency.

## Related issues

Fix #1280 High vulnerability `https-proxy-agent` install should be updated/removed



<!-- OTHER CONTRIBUTIONS // END -->
