### PR TITLE
feat(documentation) a Markdown link to mergify was missing, aligns wi…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,7 @@ The project is powered by [Eleventy](https://11ty.io). These are the configurati
 
 ### `.mergify.yml`
 
-The project uses Mergify to auto-merge certain PRs based on some conditions.
+The project uses [Mergify](https://mergify.io) to auto-merge certain PRs based on some conditions.
 
 ### `__tests__`
 

--- a/docs/br/CONTRIBUTING.md
+++ b/docs/br/CONTRIBUTING.md
@@ -159,7 +159,7 @@ O projeto é desenvolvido por [Eleventy](https://11ty.io). Estes são os arquivo
 
 ### `.mergify.yml`
 
-O projeto usa o Mergify para mesclar automaticamente determinados PRs com base em algumas condições.
+O projeto usa o [Mergify](https://mergify.io) para mesclar automaticamente determinados PRs com base em algumas condições.
 
 ### `__tests__`
 

--- a/docs/de/CONTRIBUTING.md
+++ b/docs/de/CONTRIBUTING.md
@@ -159,7 +159,7 @@ Das Projekt wird von [Eleventy](https://11ty.io) betrieben. Dies sind die Konfig
 
 ### `.mergify.yml`
 
-Das Projekt verwendet Mergify, um bestimmte PRs basierend auf bestimmten Bedingungen automatisch zusammenzuführen.
+Das Projekt verwendet [Mergify](https://mergify.io), um bestimmte PRs basierend auf bestimmten Bedingungen automatisch zusammenzuführen.
 
 ### `__tests__`
 

--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -155,7 +155,7 @@ Este proyecto usa [Eleventy](https://11ty.io). Estos son los archivos de configu
 
 ### `.mergify.yml`
 
-Este proyecto usa Mergify para incluir automáticamente ciertos PRs, basados en condiciones definidas internamente.
+Este proyecto usa [Mergify](https://mergify.io) para incluir automáticamente ciertos PRs, basados en condiciones definidas internamente.
 
 ### `__tests__`
 

--- a/docs/zh/CONTRIBUTING.md
+++ b/docs/zh/CONTRIBUTING.md
@@ -186,7 +186,7 @@ open-pixel-art
 
 ### `.mergify.yml`
 
-此项目使用 Mergify 来自动整合（auto-merge）某些特定的代码提交。
+此项目使用 [Mergify](https://mergify.io) 来自动整合（auto-merge）某些特定的代码提交。
 
 ### `__tests__`
 


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [X] I ran `npm test` locally and it passed without errors.
<!-- Delete this if the PR is for something other than a pixel -->
<!-- Delete this if the PR is for something other than a pixel -->
- [X] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description

In the Contribution documentation Eleventy and Jest both had links out to their respective sites and Mergify didn't, this PR adds that into the documentation to save the next lazy developer having to Google it.

## Related issues

https://github.com/twilio-labs/open-pixel-art/issues/1425

-->

<!-- OTHER CONTRIBUTIONS // END -->
