### PR TITLE
bug: fix random placement to not have overlaps

### DIFF
--- a/assets/javascript/party-mode.js
+++ b/assets/javascript/party-mode.js
@@ -51,8 +51,8 @@ function reset() {
 }
 
 function random() {
-  const r = () => Math.floor(Math.random() * 40) * 10;
-  transform(() => [r(), r()]);
+  const coords = allCells().sort(() => Math.random() - 0.5)
+  transform(({ i }) => [coords[i].x, coords[i].y]);
 }
 
 function order() {
@@ -117,4 +117,14 @@ function toggleImages() {
     rects.forEach(rect => canvas.appendChild(rect));
     images.forEach(image => image.remove());
   }
+}
+
+function allCells() {
+  const all = []
+  for (let j = 0; j < height; j++) {
+    for (let i = 0; i < width; i++) {
+      all.push({ x: i * 10, y: j * 10 })
+    }
+  }
+  return all
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description

Currently, clicking the random will result in some pixels overlapping. This implements a different random placement algorithm that prevents overlaps from occurring.