### PR TITLE
Added custom pixel at 30x25

### DIFF
--- a/_data/pixels.json
+++ b/_data/pixels.json
@@ -660,6 +660,7 @@
     {"y": 30, "x": 21, "color": "#00FF00", "username": "sitegui"},
     {"y": 30, "x": 22, "color": "#00FF00", "username": "izontm"},
     {"y": 30, "x": 23, "color": "#00FF00", "username": "jack-chapman"},
+    {"y": 30, "x": 25, "color": "#00ACED", "username": "Nerdwood"},
     {"y": 30, "x": 29, "color": "#3366ff", "username": "distalphalanges"},
     {"y": 30, "x": 30, "color": "#FFA500", "username": "brianmyburgh"},
     {"y": 30, "x": 31, "color": "#32a88f", "username": "SamGowland"},


### PR DESCRIPTION
Added a new pixel into the grid at the 30x25 position.

## Checklist

- [x] I ran `npm test` locally and it passed without errors.
- [x] I only edited the `_data/pixels.json` file.
- [x] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).
