### PR TITLE
refactor: use display:none to reduce DOM mutations

### DIFF
--- a/assets/javascript/party-mode.js
+++ b/assets/javascript/party-mode.js
@@ -5,10 +5,8 @@ const rects = Array.from(
 const images = Array.from(
   document.querySelectorAll('#pixel-canvas .pixel-image')
 );
-// hide image-pixels on load
-images.forEach(image => image.remove());
 
-let showImages = false;
+let imagesInitialized = false;
 
 // add additional 'x-start' and 'y-start' attributes
 rects.forEach(rect => {
@@ -176,22 +174,20 @@ function transform(transformFunction) {
 }
 
 function toggleImages() {
-  showImages = !showImages;
-  if (showImages) {
-    rects.forEach(rect => rect.remove());
+  // If switching to images for the first time, initialize.
+  if (!imagesInitialized) {
+    imagesInitialized = true;
     images.forEach(image => {
       const name = image.getAttribute('name');
-      image.classList.remove('hidden');
       image.setAttribute(
         'xlink:href',
         `//avatars.githubusercontent.com/${name}?size=20`
       );
-      canvas.appendChild(image);
     });
-  } else {
-    rects.forEach(rect => canvas.appendChild(rect));
-    images.forEach(image => image.remove());
   }
+  // Toggle display of rects and images.
+  rects.forEach(rect => rect.classList.toggle('hidden'));
+  images.forEach(image => image.classList.toggle('hidden'));
 }
 
 function allCells() {


### PR DESCRIPTION


<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

<!--

## Description
The JS currently adds and removes all rects/images each time the avatars
button is pressed. Instead, use the .hidden class to toggle which is
displayed.

## Related issues

none


-->

<!-- OTHER CONTRIBUTIONS // END -->
