### PR TITLE
fix(npm command): add alias to match TwilioQuest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "configure:merge-driver": "node scripts/configureMergeDriver.js",
     "sync-fork": "node scripts/sync.js",
     "format:sort-pixels": "node scripts/sortPixels.js",
+    "sort:open-pixels": "node scripts/sortPixels.js",
     "lint-staged": "lint-staged",
     "start": "eleventy --serve",
     "build": "eleventy",


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description

In the TwilioQuest task **Contributing to Open Source: Author Your Contribution**, under the header **Keep it sorted!**, the command advised is `npm run sort:open-pixels`.
This fix is adds another alias for `node scripts/sortPixels.js`

## Related issues

None

<!-- OTHER CONTRIBUTIONS // END -->
