### PR TITLE
fix(danger): update dangerfile script to check before/after

### DIFF
--- a/__tests__/dangerfile.test.js
+++ b/__tests__/dangerfile.test.js
@@ -19,8 +19,7 @@ const {
   handleMultipleFileChanges,
   handleSuccessfulSubmission,
   hasOnlyPixelChanges,
-  isValidNewPixelSubmission,
-  isValidPixelUpdate
+  isValidNewPixelSubmission
 } = require('../dangerfile');
 
 describe('allPatchesAreForTheSamePixel', () => {
@@ -316,67 +315,5 @@ describe('isValidNewPixelSubmission', () => {
       x: 0
     };
     expect(isValidNewPixelSubmission(pixel, 'dkundel')).toBe(true);
-  });
-});
-
-describe('isValidPixelUpdate', () => {
-  test('fails if diff overrides claimed pixel', () => {
-    const jsonPatch = {
-      before: {
-        data: [{ y: 0, x: 0, color: '#F22F46', username: 'not_unclaimed' }]
-      },
-      after: {
-        data: [{ y: 0, x: 0, color: '#F22F46', username: 'twilio' }]
-      }
-    };
-    const specificDiff = {
-      path: '/data/0/username'
-    };
-    expect(isValidPixelUpdate(jsonPatch, specificDiff, 'twilio')).toBe(false);
-  });
-
-  test('fails if username is wrong', () => {
-    const jsonPatch = {
-      before: {
-        data: [{ y: 0, x: 0, color: '#F22F46', username: '<UNCLAIMED>' }]
-      },
-      after: {
-        data: [{ y: 0, x: 0, color: '#F22F46', username: 'not_twilio' }]
-      }
-    };
-    const specificDiff = {
-      path: '/data/0/username'
-    };
-    expect(isValidPixelUpdate(jsonPatch, specificDiff, 'twilio')).toBe(false);
-  });
-
-  test('passes if is valid update', () => {
-    const jsonPatch = {
-      before: {
-        data: [{ y: 0, x: 0, color: '#F22F46', username: '<UNCLAIMED>' }]
-      },
-      after: {
-        data: [{ y: 0, x: 0, color: '#F22F46', username: 'twilio' }]
-      }
-    };
-    const specificDiff = {
-      path: '/data/0/username'
-    };
-    expect(isValidPixelUpdate(jsonPatch, specificDiff, 'twilio')).toBe(true);
-  });
-
-  test('passes if is valid new pixel', () => {
-    const jsonPatch = {
-      before: {
-        data: []
-      },
-      after: {
-        data: [{ y: 0, x: 0, color: '#F22F46', username: 'twilio' }]
-      }
-    };
-    const specificDiff = {
-      path: '/data/0/'
-    };
-    expect(isValidPixelUpdate(jsonPatch, specificDiff, 'twilio')).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->


## Description

This Pull Request is intended to fix the failing pixel commit automatic checking via danger.

It is comparing `before`/`after` in the `jsonPatch` instead of parsing the actual `diff` and it's operations.

## Related issues

#2046 

