### PR TITLE
Fix PR template license link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 - [ ] I only edited the `_data/pixels.json` file.
 <!-- Delete this if the PR is for something other than a pixel -->
 - [ ] I entered the `username` in the `pixels.json` that I'm also using to create this pull request.
-- [ ] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).
+- [ ] I acknowledge that all my contributions will be made under the project's [license](https://github.com/twilio-labs/open-pixel-art/blob/master/LICENSE).
 
 <!-- To check a task, put a "x" between the brackets, similar to [x] -->
 


### PR DESCRIPTION
## Description

The license link on the repo's PR template led to a 404 page. This PR fixes it by changing it to an absolute link.

## Related issues

Closes #2774.
