### PR TITLE
add workaround information to the bug(#2046) in bot response

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,3 @@
-
 pull_request_rules:
   - name: inform people about merge conflict
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,7 +24,7 @@ pull_request_rules:
       - 'status-failure=build'
     actions:
       comment:
-        message: 'Unfortunately the automatic code review has failed. Please click the details button for more information. If the details reveal a fail in Danger please note that there is currently a known issue (\#2046). Follow the steps mentioned here: https://github.com/twilio-labs/open-pixel-art/issues/2046#issuecomment-741712052 that explains a workaround to the bug. If the issue persists, @dkundel will merge your PR manually in the coming days. Sorry for the inconvenience.'
+        message: 'Unfortunately the automatic code review has failed. Please click the details button for more information. If the details reveal a fail in Danger please note that there is currently a known issue (\#2046). Follow the steps mentioned here: https://github.com/twilio-labs/open-pixel-art/issues/2046#issuecomment-741712052 that describe a workaround to the bug. If the issue persists, @dkundel will merge your PR manually in the coming days. Sorry for the inconvenience.'
       label:
         add:
           - 'needs-help'

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,4 @@
+
 pull_request_rules:
   - name: inform people about merge conflict
     conditions:
@@ -23,7 +24,7 @@ pull_request_rules:
       - 'status-failure=build'
     actions:
       comment:
-        message: 'Unfortunately the automatic code review has failed. Please click the details button for more information. If the details reveal a fail in Danger please note that there is currently a known issue (\#2046) and @dkundel will merge your PR manually in the coming days. Sorry for the inconvenience.'
+        message: 'Unfortunately the automatic code review has failed. Please click the details button for more information. If the details reveal a fail in Danger please note that there is currently a known issue (\#2046). Follow the steps mentioned here: https://github.com/twilio-labs/open-pixel-art/issues/2046#issuecomment-741712052 that explains a workaround to the bug. If the issue persists, @dkundel will merge your PR manually in the coming days. Sorry for the inconvenience.'
       label:
         add:
           - 'needs-help'


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description

Added workaround link for a bug(#2046) in mergify bot response for better visibility.

## Related issues

https://github.com/twilio-labs/open-pixel-art/issues/2046

<!-- OTHER CONTRIBUTIONS // END -->
