### PR TITLE
Exit after configure Fix #2423

### DIFF
--- a/scripts/configureMergeDriver.js
+++ b/scripts/configureMergeDriver.js
@@ -15,10 +15,12 @@ async function run() {
   spinner.succeed('Configured custom merge driver');
 }
 
-run().catch(err => {
-  if (spinner) {
-    spinner.fail('Failed to configure custom merge driver for pixels.json');
-  }
-  console.error(err.all);
-  process.exit(1);
-});
+run()
+  .then(() => process.exit(0))
+  .catch(err => {
+    if (spinner) {
+      spinner.fail('Failed to configure custom merge driver for pixels.json');
+    }
+    console.error(err.all);
+    process.exit(1);
+  });


### PR DESCRIPTION
<!-- Thank you for contributing a pixel to the Open Pixel Art project! -->

<!-- PIXEL CONTRIBUTIONS // START -->

## Checklist

<!-- Before submitting your pull request please make sure you checked the following tasks: -->

- [x] I ran `npm test` locally and it passed without errors.
- [x] I acknowledge that all my contributions will be made under the project's [license](../LICENSE).

<!-- To check a task, put a "x" between the brackets, similar to [x] -->

<!-- PIXEL CONTRIBUTIONS // END -->

<!-- OTHER CONTRIBUTIONS // START -->


<!-- If you are contributing more than a pixel, please uncomment the part below and fill out the rest of the template -->

## Description

Explicitly exit after the async configure step completes.

## Related issues

Fixes #2423

<!-- OTHER CONTRIBUTIONS // END -->
